### PR TITLE
Added iosIsDestructiveAction and iosIsDefaultAction params

### DIFF
--- a/lib/src/basic_dialog_action.dart
+++ b/lib/src/basic_dialog_action.dart
@@ -15,12 +15,10 @@ class BasicDialogActionData extends BaseActionData {
 }
 
 /// Widget class that holds the possible widgets to be shown in a [BaseDialog].
-/// For example, [FlatButton] for Android and [CupertinoDialogAction] for iOS.
-class BasicDialogAction extends BaseDialog<FlatButton, CupertinoDialogAction> {
-  BasicDialogAction({
-    this.onPressed,
-    this.title,
-  });
+/// For example, [TextButton] for Android and [CupertinoDialogAction] for iOS.
+class BasicDialogAction extends BaseDialog<TextButton, CupertinoDialogAction> {
+  BasicDialogAction(
+      {this.onPressed, this.title, this.iosIsDestructiveAction = false, this.iosIsDefaultAction = false});
 
   /// Handles the [VoidCallback] whenever an action is pressed.
   final VoidCallback? onPressed;
@@ -30,9 +28,28 @@ class BasicDialogAction extends BaseDialog<FlatButton, CupertinoDialogAction> {
   /// or a [Container] widget that contains a [Text] widget.
   final Widget? title;
 
+  /// Whether this action destroys an object.
+  ///
+  /// For example, an action that deletes an email is destructive.
+  ///
+  /// Defaults to false and cannot be null.
+  /// Only used on iOS
+  final bool iosIsDestructiveAction;
+
+  /// Set to true if button is the default choice in the dialog.
+  ///
+  /// Default buttons have bold text. Similar to
+  /// [UIAlertController.preferredAction](https://developer.apple.com/documentation/uikit/uialertcontroller/1620102-preferredaction),
+  /// but more than one action can have this attribute set to true in the same
+  /// [CupertinoAlertDialog]
+  ///
+  /// This parameters defaults to false and cannot be null.
+  /// Only used on iOS
+  final bool iosIsDefaultAction;
+
   @override
-  FlatButton buildAndroidWidget(BuildContext context) {
-    return FlatButton(
+  TextButton buildAndroidWidget(BuildContext context) {
+    return TextButton(
       onPressed: onPressed,
       child: title ?? Container(),
     );
@@ -43,6 +60,8 @@ class BasicDialogAction extends BaseDialog<FlatButton, CupertinoDialogAction> {
     return CupertinoDialogAction(
       onPressed: onPressed,
       child: title ?? Container(),
+      isDestructiveAction: iosIsDestructiveAction,
+      isDefaultAction: iosIsDefaultAction,
     );
   }
 }

--- a/lib/src/basic_dialog_alert.dart
+++ b/lib/src/basic_dialog_alert.dart
@@ -23,7 +23,7 @@ class BasicDialogAlert extends BaseDialog<AlertDialog, CupertinoAlertDialog> {
   BasicDialogAlert({
     this.title,
     this.content,
-    this.actions = const <Widget>[],
+    this.actions,
     this.android,
     this.ios,
   });
@@ -35,7 +35,7 @@ class BasicDialogAlert extends BaseDialog<AlertDialog, CupertinoAlertDialog> {
   final Widget? content;
 
   /// Represents appropriate list of [Widget]'s to display in actions section.
-  final List<Widget> actions;
+  final List<Widget>? actions;
 
   /// Additional configuration on top of [BasicDialogAlertData]'s default configuration.
   final BaseDialogBuilder<BasicDialogAlertData>? android;
@@ -69,7 +69,7 @@ class BasicDialogAlert extends BaseDialog<AlertDialog, CupertinoAlertDialog> {
     return CupertinoAlertDialog(
       title: data?.title ?? title,
       content: data?.content ?? content,
-      actions: data?.actions ?? actions,
+      actions: data?.actions ?? actions ?? [],
     );
   }
 }


### PR DESCRIPTION
I have added Added `isDestructiveAction` and `isDefaultAction` params for ios dialogs as discussed before. Tried to name them accordingly to make it clear they are only valid for ios.